### PR TITLE
fix: add graphql permissions and APPSYNC_API_URL env variable in Lambda Function

### DIFF
--- a/packages/@cdklabs/genai-idp-bedrock-llm-processor/src/internal/ocr-function.ts
+++ b/packages/@cdklabs/genai-idp-bedrock-llm-processor/src/internal/ocr-function.ts
@@ -179,5 +179,8 @@ export class OcrFunction extends PythonFunction {
         }),
       );
     }
+
+    // Grant AppSync permissions if API is provided
+    props.api?.grantMutation(this);
   }
 }

--- a/packages/@cdklabs/genai-idp-bedrock-llm-processor/src/internal/process-results-function.ts
+++ b/packages/@cdklabs/genai-idp-bedrock-llm-processor/src/internal/process-results-function.ts
@@ -134,5 +134,8 @@ export class ProcessResultsFunction extends PythonFunction {
     Metric.grantPutMetricData(this);
     props.trackingTable.grantReadWriteData(this);
     props.encryptionKey?.grantEncryptDecrypt(this);
+
+    // Grant AppSync permissions if API is provided
+    props.api?.grantMutation(this);
   }
 }

--- a/packages/@cdklabs/genai-idp-bedrock-llm-processor/src/internal/summarization-function.ts
+++ b/packages/@cdklabs/genai-idp-bedrock-llm-processor/src/internal/summarization-function.ts
@@ -141,6 +141,7 @@ export class SummarizationFunction extends PythonFunction {
         LOG_LEVEL: props.logLevel ?? LogLevel.INFO,
         TRACKING_TABLE: props.trackingTable.tableName,
         DOCUMENT_TRACKING_MODE: props.api ? "appsync" : "dynamodb",
+        ...(props.api && { APPSYNC_API_URL: props.api.graphqlUrl }),
       },
     });
 

--- a/packages/@cdklabs/genai-idp-bedrock-llm-processor/test/nag/__snapshots__/bedrock-llm-processor.test.ts.snap
+++ b/packages/@cdklabs/genai-idp-bedrock-llm-processor/test/nag/__snapshots__/bedrock-llm-processor.test.ts.snap
@@ -1311,6 +1311,11 @@ exports[`BedrockLlmProcessor CDK Nag Compliance BedrockLlmProcessor with suppres
               "Effect": "Allow",
               "Resource": "*",
             },
+            {
+              "Action": "appsync:GraphQL",
+              "Effect": "Allow",
+              "Resource": "arn:aws:appsync:us-east-1:123456789012:apis/test-api-id/graphql",
+            },
           ],
           "Version": "2012-10-17",
         },
@@ -1572,6 +1577,11 @@ exports[`BedrockLlmProcessor CDK Nag Compliance BedrockLlmProcessor with suppres
                   "Arn",
                 ],
               },
+            },
+            {
+              "Action": "appsync:GraphQL",
+              "Effect": "Allow",
+              "Resource": "arn:aws:appsync:us-east-1:123456789012:apis/test-api-id/graphql",
             },
           ],
           "Version": "2012-10-17",
@@ -2755,6 +2765,7 @@ exports[`BedrockLlmProcessor CDK Nag Compliance BedrockLlmProcessor with suppres
         },
         "Environment": {
           "Variables": {
+            "APPSYNC_API_URL": "https://example.com/graphql",
             "CONFIGURATION_TABLE_NAME": {
               "Ref": "MockConfigTable9B38FA67",
             },


### PR DESCRIPTION
1. Added required permission to access graphql based on error during testing in ocr and process result function.
2. Adding missing env variable in Summarisation Function