### PR TITLE
chore(upstream): added git checkout to the update-upstream-sources

### DIFF
--- a/.github/workflows/update-upstream-sources.yml
+++ b/.github/workflows/update-upstream-sources.yml
@@ -13,6 +13,8 @@ jobs:
       id-token: none
       pull-requests: write
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:

--- a/projenrc/upstream-source-sync.ts
+++ b/projenrc/upstream-source-sync.ts
@@ -74,6 +74,10 @@ git add ${targetDir}
       },
       runsOn: ['ubuntu-latest'],
       steps: [
+        {
+          name: 'Checkout',
+          uses: 'actions/checkout@v4',
+        },
         ...project.renderWorkflowSetup(),
         {
           name: 'Update upstream sources',


### PR DESCRIPTION
Corrects the behavior of the update-upstream-sources so that we can create the upstream parity upgrade PRs.