### PR TITLE
chore: fixing the update-upstream-sources workflow

### DIFF
--- a/.github/workflows/update-upstream-sources.yml
+++ b/.github/workflows/update-upstream-sources.yml
@@ -9,10 +9,12 @@ jobs:
   update_upstream_sources:
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write
       id-token: none
       pull-requests: write
     steps:
+      - name: Checkout
+        uses: actions/checkout@v5
       - name: Setup Node.js
         uses: actions/setup-node@v5
         with:
@@ -56,6 +58,9 @@ jobs:
             echo "changes=false" >> $GITHUB_OUTPUT
             echo "No changes detected"
           fi
+      - name: Delete existing PR branch
+        if: steps.check-changes.outputs.changes == 'true'
+        run: git push origin --delete update-upstream-sources || true
       - name: Create Pull Request
         id: create-pr
         if: steps.check-changes.outputs.changes == 'true'

--- a/projenrc/upstream-source-sync.ts
+++ b/projenrc/upstream-source-sync.ts
@@ -68,12 +68,16 @@ git add ${targetDir}
 
     this.workflow.addJob(UPDATE_JOB_ID, {
       permissions: {
-        contents: github.workflows.JobPermission.READ,
+        contents: github.workflows.JobPermission.WRITE,
         idToken: github.workflows.JobPermission.NONE,
         pullRequests: github.workflows.JobPermission.WRITE,
       },
       runsOn: ['ubuntu-latest'],
       steps: [
+        {
+          name: 'Checkout',
+          uses: 'actions/checkout@v5',
+        },
         ...project.renderWorkflowSetup(),
         {
           name: 'Update upstream sources',
@@ -91,6 +95,11 @@ git add ${targetDir}
             '  echo "No changes detected"',
             'fi',
           ].join('\n'),
+        },
+        {
+          name: 'Delete existing PR branch',
+          if: 'steps.check-changes.outputs.changes == \'true\'',
+          run: 'git push origin --delete update-upstream-sources || true',
         },
         {
           name: 'Create Pull Request',


### PR DESCRIPTION
The `update-upstream-sources` workflow was failing because `renderWorkflowSetup()` 
doesn't include a checkout step — only node setup and dependency install. The 
`git add sources` at the end of the sync script failed with 
`fatal: not a git repository`.

- Add explicit `actions/checkout@v5` step
- Bump `contents` permission to `write` for checkout and branch operations
- Delete the PR branch before re-creating it so each run fully overwrites 
  previous content instead of merging on top