### PR TITLE
chore(ci): update-upstream-sources workflow credential fix

### DIFF
--- a/.github/workflows/update-upstream-sources.yml
+++ b/.github/workflows/update-upstream-sources.yml
@@ -15,8 +15,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v5
-        with:
-          token: ${{ secrets.PROJEN_GITHUB_TOKEN }}
       - name: Setup Node.js
         uses: actions/setup-node@v5
         with:

--- a/.github/workflows/update-upstream-sources.yml
+++ b/.github/workflows/update-upstream-sources.yml
@@ -64,7 +64,7 @@ jobs:
       - name: Create Pull Request
         id: create-pr
         if: steps.check-changes.outputs.changes == 'true'
-        uses: peter-evans/create-pull-request@v5
+        uses: peter-evans/create-pull-request@v8
         with:
           token: ${{ secrets.PROJEN_GITHUB_TOKEN }}
           commit-message: "feat(sources): update upstream sources"

--- a/.github/workflows/update-upstream-sources.yml
+++ b/.github/workflows/update-upstream-sources.yml
@@ -60,9 +60,6 @@ jobs:
             echo "changes=false" >> $GITHUB_OUTPUT
             echo "No changes detected"
           fi
-      - name: Delete existing PR branch
-        if: steps.check-changes.outputs.changes == 'true'
-        run: git push origin --delete update-upstream-sources || true
       - name: Create Pull Request
         id: create-pr
         if: steps.check-changes.outputs.changes == 'true'
@@ -71,6 +68,7 @@ jobs:
           token: ${{ secrets.PROJEN_GITHUB_TOKEN }}
           commit-message: "feat(sources): update upstream sources"
           title: "feat(sources): update upstream sources"
+          force-push: always
           body: |-
             > ⚠️ This Pull Request updates weekly and will overwrite **all** manual changes pushed to the branch
 

--- a/.github/workflows/update-upstream-sources.yml
+++ b/.github/workflows/update-upstream-sources.yml
@@ -15,6 +15,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v5
+        with:
+          token: ${{ secrets.PROJEN_GITHUB_TOKEN }}
       - name: Setup Node.js
         uses: actions/setup-node@v5
         with:

--- a/projenrc/upstream-source-sync.ts
+++ b/projenrc/upstream-source-sync.ts
@@ -100,11 +100,6 @@ git add ${targetDir}
           ].join('\n'),
         },
         {
-          name: 'Delete existing PR branch',
-          if: 'steps.check-changes.outputs.changes == \'true\'',
-          run: 'git push origin --delete update-upstream-sources || true',
-        },
-        {
           name: 'Create Pull Request',
           id: 'create-pr',
           if: 'steps.check-changes.outputs.changes == \'true\'',
@@ -113,6 +108,7 @@ git add ${targetDir}
             'token': '${{ secrets.PROJEN_GITHUB_TOKEN }}',
             'commit-message': 'feat(sources): update upstream sources',
             'title': 'feat(sources): update upstream sources',
+            'force-push': 'always',
             'body': [
               '> ⚠️ This Pull Request updates weekly and will overwrite **all** manual changes pushed to the branch',
               '',

--- a/projenrc/upstream-source-sync.ts
+++ b/projenrc/upstream-source-sync.ts
@@ -105,7 +105,7 @@ git add ${targetDir}
           name: 'Create Pull Request',
           id: 'create-pr',
           if: 'steps.check-changes.outputs.changes == \'true\'',
-          uses: 'peter-evans/create-pull-request@v5',
+          uses: 'peter-evans/create-pull-request@v8',
           with: {
             'token': '${{ secrets.PROJEN_GITHUB_TOKEN }}',
             'commit-message': 'feat(sources): update upstream sources',

--- a/projenrc/upstream-source-sync.ts
+++ b/projenrc/upstream-source-sync.ts
@@ -77,6 +77,9 @@ git add ${targetDir}
         {
           name: 'Checkout',
           uses: 'actions/checkout@v5',
+          with: {
+            'token': '${{ secrets.PROJEN_GITHUB_TOKEN }}',
+          },
         },
         ...project.renderWorkflowSetup(),
         {

--- a/projenrc/upstream-source-sync.ts
+++ b/projenrc/upstream-source-sync.ts
@@ -77,9 +77,6 @@ git add ${targetDir}
         {
           name: 'Checkout',
           uses: 'actions/checkout@v5',
-          with: {
-            'token': '${{ secrets.PROJEN_GITHUB_TOKEN }}',
-          },
         },
         ...project.renderWorkflowSetup(),
         {


### PR DESCRIPTION
## Problem

The scheduled `update-upstream-sources` workflow fails when the `update-upstream-sources` branch already exists from a previous run. The `peter-evans/create-pull-request@v5` action attempts to rebase the existing branch onto `main`, which requires fetching the base branch — and that fetch fails with:

>  fatal: could not read Username for 'https://github.com': No such device or address


This happens because the action's credential handling breaks during the rebase flow (unsets the checkout token, sets its own, but the git fetch doesn't pick it up).

## Fix

- **Bump `peter-evans/create-pull-request` from v5 to v8** — resolves the Node.js 20 deprecation warning (forced to Node.js 24 starting June 2, 2026)
- **Add `force-push: always`** — skips the rebase entirely and force-pushes the branch content each run. This matches the workflow's intent: the branch is a rolling snapshot of the latest upstream sources, not an incremental history.
- **Remove the "Delete existing PR branch" step** — redundant now that force-push handles the overwrite.

## Testing

This workflow cannot be tested from a feature branch because `create-pull-request` uses the current branch as context. It must be tested by merging to `main` and triggering via `workflow_dispatch`.
