### PR TITLE
chore: Adding SeedFarmer capability configuration files and helper script

### DIFF
--- a/samples/sample-bedrock/capability/README.md
+++ b/samples/sample-bedrock/capability/README.md
@@ -1,0 +1,74 @@
+# Intelligent Document Processing with Amazon Bedrock
+
+Serverless document processing pipeline using Amazon Bedrock foundation models for classification, extraction, summarization, and evaluation — with a web UI for document management.
+
+## What Gets Deployed
+
+- **Amazon S3** — Document input, working storage, and output buckets
+- **Amazon Bedrock** — Document classification and information extraction
+- **Amazon Textract** — OCR processing
+- **AWS Step Functions** — Document processing workflow orchestration
+- **AWS Lambda** — Processing task handlers
+- **Amazon DynamoDB** — Processing status tracking
+- **Amazon AppSync** — GraphQL API for status queries and real-time updates
+- **Amazon CloudFront** — Web application hosting
+- **Amazon Cognito** — User authentication
+- **Amazon CloudWatch** — Monitoring and metrics
+- **AWS KMS** — Encryption for all data at rest
+- **Amazon VPC** — Fully private deployment with no internet gateway
+
+## Inputs
+
+| Name | Required | Description |
+|------|----------|-------------|
+| `ADMIN_EMAIL` | No | Email address for the admin user. A temporary password will be sent to this address. Leave empty to skip. |
+| `CONFIG_S3_URI` | No | S3 URI (`s3://bucket/key`) of a custom processor configuration YAML in the target account. If not provided, the default configuration is used. |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| `WebSiteUrl` | URL of the CloudFront-hosted web application |
+
+## Using the Application
+
+1. Open the `WebSiteUrl` in a browser
+2. Log in with the admin email and temporary password (check your inbox)
+3. Upload documents through the web interface
+4. Monitor processing status and view extraction results
+
+## Processor Configuration
+
+By default, the pipeline deploys with a **lending package sample** configuration that classifies and extracts data from common lending documents (pay stubs, bank statements, tax forms, etc.).
+
+To use a custom configuration, upload a YAML config file to an S3 bucket in the target environment account and provide its URI as `CONFIG_S3_URI`. The configuration defines:
+
+- **Document classes** — Types of documents the pipeline can classify
+- **Extraction schemas** — Fields to extract from each document type
+- **Model selection** — Which Bedrock models to use for each task
+- **Prompts** — Custom prompts for classification, extraction, and summarization
+
+## Prerequisites
+
+- Amazon Bedrock model access must be enabled in the target account/region for the models used by the configuration (default: Claude and Titan models)
+- The target account must be CDK-bootstrapped
+
+## Security
+
+- All data encrypted at rest with a customer-managed KMS key
+- Deployed in a fully private VPC (no internet gateway, all AWS access via VPC endpoints)
+- Least-privilege IAM permissions for all components
+- CloudWatch logs encrypted
+
+## Cost Considerations
+
+Key cost drivers:
+
+- **Amazon Bedrock** — Per-token charges for document processing
+- **Amazon Textract** — Per-page OCR charges
+- **VPC Endpoints** — Hourly charges per interface endpoint (~14 endpoints)
+- **Amazon S3 / DynamoDB / Lambda** — Usage-based charges
+
+## License
+
+Apache License 2.0

--- a/samples/sample-bedrock/capability/assets/example-input.yaml
+++ b/samples/sample-bedrock/capability/assets/example-input.yaml
@@ -1,0 +1,2 @@
+ADMIN_EMAIL: "user@example.com"
+CONFIG_S3_URI: "Optional, eg.: s3://my-bucket/configs/my-processor-config.yaml"

--- a/samples/sample-bedrock/capability/capability.yaml
+++ b/samples/sample-bedrock/capability/capability.yaml
@@ -1,0 +1,27 @@
+uniqueId: genai-idp-bedrock-llm
+path: genai-idp-bedrock-llm
+version: 1.0.0
+type: SeedFarmer
+name: GenAI IDP - Intelligent Document Processing
+description: Intelligent Document Processing pipeline using Amazon Bedrock foundation models. Deploys a complete serverless solution for document classification, extraction, summarization, and evaluation with a web UI for document management.
+labels:
+  - DocumentProcessing
+  - Bedrock
+  - IDP
+  - GenAI
+input:
+  - name: ADMIN_EMAIL
+    description: Email address for the admin user (receives temporary password). Leave empty to skip admin user creation.
+    isRequired: false
+    defaultValue: ""
+  - name: CONFIG_S3_URI
+    description: S3 URI (s3://bucket/key) of a custom processor configuration YAML file in the target environment account. If not provided, the built-in lending package sample configuration is used.
+    isRequired: false
+    defaultValue: ""
+environments:
+  - name: DEPLOYMENT
+    description: Target AWS environment for the IDP processing pipeline
+    label: Deployment Environment
+output:
+  - name: WebSiteUrl
+    description: URL of the CloudFront-hosted web application for document processing

--- a/samples/sample-bedrock/capability/deployment.yaml
+++ b/samples/sample-bedrock/capability/deployment.yaml
@@ -1,0 +1,13 @@
+name: ${DEPLOYMENT_NAME}
+toolchainRegion: ${PLATFORM_REGION}
+groups:
+  - name: idp-bedrock
+    path: idp-bedrock-module.yaml
+targetAccountMappings:
+  - alias: primary
+    accountId: ${DEPLOYMENT_ACCOUNT}
+    default: true
+    regionMappings:
+      - region: ${DEPLOYMENT_REGION}
+        default: true
+forceDependencyRedeploy: True

--- a/samples/sample-bedrock/capability/deployspec.yaml
+++ b/samples/sample-bedrock/capability/deployspec.yaml
@@ -1,0 +1,26 @@
+deploy:
+  phases:
+    install:
+      commands:
+        - npm install -g aws-cdk
+        - nvm use 22 || true
+        - npm install --legacy-peer-deps
+    build:
+      commands:
+        - |
+          CDK_CONTEXT_ARGS=""
+          if [ -n "${SEEDFARMER_PARAMETER_CONFIG_S3_URI:-}" ]; then
+            echo "Downloading custom processor config from ${SEEDFARMER_PARAMETER_CONFIG_S3_URI}"
+            aws s3 cp "${SEEDFARMER_PARAMETER_CONFIG_S3_URI}" ./custom-config.yaml
+            CDK_CONTEXT_ARGS="-c configPath=./custom-config.yaml"
+          else
+            echo "No CONFIG_S3_URI provided, using default processor config"
+          fi
+          npx cdk deploy --require-approval never --parameters AdminEmail="${SEEDFARMER_PARAMETER_ADMIN_EMAIL:-}" ${CDK_CONTEXT_ARGS} --all --outputs-file cdk-outputs.json
+        - python3 -c "import json; d=json.load(open('cdk-outputs.json')); stack=list(d.values())[0]; print(json.dumps({'metadata':json.dumps(stack)}))" > output.json
+        - seedfarmer metadata convert -f output.json -jq .metadata
+destroy:
+  phases:
+    build:
+      commands:
+        - npx cdk destroy --force --all

--- a/samples/sample-bedrock/capability/idp-bedrock-module.yaml
+++ b/samples/sample-bedrock/capability/idp-bedrock-module.yaml
@@ -1,0 +1,10 @@
+name: idp-bedrock-llm
+path: app
+targetAccount: primary
+parameters:
+  - name: admin-email
+    valueFrom:
+      envVariable: ADMIN_EMAIL
+  - name: config-s3-uri
+    valueFrom:
+      envVariable: CONFIG_S3_URI

--- a/samples/sample-bedrock/capability/seedfarmer.yaml
+++ b/samples/sample-bedrock/capability/seedfarmer.yaml
@@ -1,0 +1,2 @@
+project: genaieh
+description: GenAI IDP Bedrock Document Processing capability

--- a/samples/sample-bedrock/scripts/package-capability.sh
+++ b/samples/sample-bedrock/scripts/package-capability.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Packages the sample-bedrock CDK app as a capability .tgz
+#
+# Usage: ./package-capability.sh [output-path]
+#   output-path: Optional. Defaults to ./genai-idp-bedrock-llm-1.0.0.tgz
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+OUTPUT_PATH="${1:-${SCRIPT_DIR}/genai-idp-bedrock-llm-1.0.0.tgz}"
+TEMP_DIR=$(mktemp -d)
+CAPABILITY_DIR_NAME="genai-idp-bedrock-llm"
+
+cleanup() {
+    rm -rf "$TEMP_DIR"
+}
+trap cleanup EXIT
+
+PACKAGE_DIR="${TEMP_DIR}/package/${CAPABILITY_DIR_NAME}"
+mkdir -p "$PACKAGE_DIR"
+
+echo "Copying capability metadata files..."
+cp -R "$PROJECT_DIR/capability/." "$PACKAGE_DIR/"
+
+echo "Copying CDK app into app/ subdirectory..."
+APP_DIR="$PACKAGE_DIR/app"
+rsync -a --exclude node_modules --exclude cdk.out --exclude capability --exclude scripts \
+      --exclude .projen --exclude .git --exclude coverage --exclude test-reports \
+      --exclude dist --exclude '*.tgz' --exclude .DS_Store --exclude README.md \
+      "$PROJECT_DIR/" "$APP_DIR/"
+
+echo "Copying deployspec into app/..."
+mv "$PACKAGE_DIR/deployspec.yaml" "$APP_DIR/"
+
+echo "Patching dependency versions for public npm..."
+sed -i.bak 's/"@cdklabs\/genai-idp": "\^0\.0\.0"/"@cdklabs\/genai-idp": "^0.3.0"/' "$APP_DIR/package.json"
+sed -i.bak 's/"@cdklabs\/genai-idp-bedrock-llm-processor": "\^0\.0\.0"/"@cdklabs\/genai-idp-bedrock-llm-processor": "^0.3.0"/' "$APP_DIR/package.json"
+rm -f "$APP_DIR/package.json.bak"
+
+echo "Removing projen build hook from cdk.json..."
+sed -i.bak '/"build": "npx projen bundle"/d' "$APP_DIR/cdk.json"
+rm -f "$APP_DIR/cdk.json.bak"
+
+echo "Creating archive..."
+tar -czf "$OUTPUT_PATH" -C "$TEMP_DIR" package
+
+echo "Done. Capability package: $OUTPUT_PATH"

--- a/samples/sample-bedrock/src/bedrock-llm-stack.ts
+++ b/samples/sample-bedrock/src/bedrock-llm-stack.ts
@@ -178,10 +178,15 @@ export class BedrockLlmStack extends Stack {
     // 4.    Creating the processor, the actual engine for performing the IDP function.
 
     // 4.1   Creating the Bedrock LLM processor that uses Amazon Bedrock foundation models for document processing.
+    const configPath = this.node.tryGetContext("configPath");
+    const configuration = configPath
+      ? BedrockLlmProcessorConfiguration.fromFile(configPath)
+      : BedrockLlmProcessorConfiguration.lendingPackageSample();
+
     const processor = new BedrockLlmProcessor(this, "Processor", {
       environment,
       configurationBucket,
-      configuration: BedrockLlmProcessorConfiguration.lendingPackageSample(),
+      configuration,
     });
 
     // 2.2.  Creating the actual API that will be used by the UI (user interactions) and the processing environment


### PR DESCRIPTION
- Let the bedrock sample app accept a processor config file via CDK context
- Adding capability-related config files to Bedrock sample - these enable seedfarmer-based deployment automations
- Adding helper shell script which does the following:

1. Creates a new folder
2. Copies the config files and the sample CDK app in a proper folder structure
3. Replaces sample README with a more generic README about the solution
4. Replaces npm version for IDP-related npm packages to be the latest (0.3.x) instead of workspace version (0.0.0)
5. Removes placeholder projen script from cdk.json
6. Creates a tar archive